### PR TITLE
Version 1.2

### DIFF
--- a/rayshud-Installer/App.config
+++ b/rayshud-Installer/App.config
@@ -17,7 +17,7 @@
         <value>master</value>
       </setting>
       <setting name="GitSettings" serializeAs="String">
-        <value>https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-installer/settings.json</value>
+        <value>https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-Installer/settings.json</value>
       </setting>
       <setting name="GitVersion" serializeAs="String">
         <value>https://raw.githubusercontent.com/raysfire/rayshud/master/README.md</value>
@@ -69,6 +69,12 @@
       </setting>
       <setting name="ErrorRemove" serializeAs="String">
         <value>An error occurred while attempting to remove rayshud</value>
+      </setting>
+      <setting name="InstallerVersion" serializeAs="String">
+        <value>https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-Installer/Properties/AssemblyInfo.cs</value>
+      </setting>
+      <setting name="InstallerUpdate" serializeAs="String">
+        <value>A new version of the installer is available on GitHub! Download it here: https://github.com/CriticalFlaw/rayshud-Installer/releases</value>
       </setting>
     </rayshud_Installer.Properties.Settings>
   </userSettings>

--- a/rayshud-Installer/Main.Designer.cs
+++ b/rayshud-Installer/Main.Designer.cs
@@ -56,6 +56,7 @@
             this.lblUberFlashColor = new System.Windows.Forms.Label();
             this.lblUberFullColor = new System.Windows.Forms.Label();
             this.gbSettings = new System.Windows.Forms.GroupBox();
+            this.cbDamageValuePos = new System.Windows.Forms.CheckBox();
             this.cbMenuClassImages = new System.Windows.Forms.CheckBox();
             this.cbDisguiseImage = new System.Windows.Forms.CheckBox();
             this.lblHUDVersion = new System.Windows.Forms.Label();
@@ -452,6 +453,7 @@
             // 
             // gbSettings
             // 
+            this.gbSettings.Controls.Add(this.cbDamageValuePos);
             this.gbSettings.Controls.Add(this.cbMenuClassImages);
             this.gbSettings.Controls.Add(this.cbDisguiseImage);
             this.gbSettings.Controls.Add(this.lblHUDVersion);
@@ -467,15 +469,27 @@
             this.gbSettings.TabStop = false;
             this.gbSettings.Text = "Settings";
             // 
+            // cbDamageValuePos
+            // 
+            this.cbDamageValuePos.AutoSize = true;
+            this.cbDamageValuePos.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cbDamageValuePos.Location = new System.Drawing.Point(153, 99);
+            this.cbDamageValuePos.Name = "cbDamageValuePos";
+            this.cbDamageValuePos.Size = new System.Drawing.Size(156, 20);
+            this.cbDamageValuePos.TabIndex = 17;
+            this.cbDamageValuePos.Text = "Damage Above Ammo";
+            this.cbDamageValuePos.UseVisualStyleBackColor = true;
+            this.cbDamageValuePos.CheckedChanged += new System.EventHandler(this.cbDamageValuePos_CheckedChanged);
+            // 
             // cbMenuClassImages
             // 
             this.cbMenuClassImages.AutoSize = true;
             this.cbMenuClassImages.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cbMenuClassImages.Location = new System.Drawing.Point(8, 99);
             this.cbMenuClassImages.Name = "cbMenuClassImages";
-            this.cbMenuClassImages.Size = new System.Drawing.Size(162, 20);
+            this.cbMenuClassImages.Size = new System.Drawing.Size(130, 20);
             this.cbMenuClassImages.TabIndex = 16;
-            this.cbMenuClassImages.Text = "Main Menu Class Images";
+            this.cbMenuClassImages.Text = "Menu Class Images";
             this.cbMenuClassImages.UseVisualStyleBackColor = true;
             this.cbMenuClassImages.CheckedChanged += new System.EventHandler(this.cbMenuClassImages_CheckedChanged);
             // 
@@ -1330,5 +1344,6 @@
         private System.Windows.Forms.Button btnGitIssue;
         private System.Windows.Forms.Button btnSteamGroup;
         private System.Windows.Forms.CheckBox cbMenuClassImages;
+        private System.Windows.Forms.CheckBox cbDamageValuePos;
     }
 }

--- a/rayshud-Installer/Main.cs
+++ b/rayshud-Installer/Main.cs
@@ -67,6 +67,17 @@ namespace rayshud_Installer
                 var textFromURLArray = textFromURL.Split('\n');
                 // Retrieve the latest version number from the README
                 txtLiveVersion.Text = textFromURLArray[textFromURLArray.Length - 2];
+
+                // Get the installed assembly version
+                System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
+                FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+
+                // Download the latest rayshud assembly file
+                textFromURL = client.DownloadString(Properties.Settings.Default.InstallerVersion);
+                textFromURLArray = textFromURL.Split('\n');
+                // Retrieve and compare the installer version numbers
+                if (textFromURLArray[textFromURLArray.Length - 2] != $"[assembly: AssemblyFileVersion(\"{versionInfo.FileVersion}\")]")
+                    MessageBox.Show(Properties.Settings.Default.InstallerVersion, "New Installer Version Available!", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (Exception ex)
             {

--- a/rayshud-Installer/Main.cs
+++ b/rayshud-Installer/Main.cs
@@ -572,9 +572,9 @@ namespace rayshud_Installer
                 }
 
                 // Spy Disguise Image and Uber Animation - uncomment all
-                var crosshairPulseIndex = 77;
-                var disguiseImageIndex = 84;
-                var uberAnimationIndex = 99;
+                var crosshairPulseIndex = 80;
+                var disguiseImageIndex = 91;
+                var uberAnimationIndex = 107;
                 var lines = File.ReadAllLines(animations);
                 lines[(disguiseImageIndex + 0) - 1] = lines[(disguiseImageIndex + 0) - 1].Replace("//", string.Empty);
                 lines[(disguiseImageIndex + 1) - 1] = lines[(disguiseImageIndex + 1) - 1].Replace("//", string.Empty);
@@ -634,11 +634,19 @@ namespace rayshud_Installer
                 {
                     lines[(crosshairPulseIndex + 0) - 1] = lines[(crosshairPulseIndex + 0) - 1].Replace("//", string.Empty);
                     lines[(crosshairPulseIndex + 1) - 1] = lines[(crosshairPulseIndex + 1) - 1].Replace("//", string.Empty);
+                    lines[(crosshairPulseIndex + 2) - 1] = lines[(crosshairPulseIndex + 2) - 1].Replace("//", string.Empty);
+                    lines[(crosshairPulseIndex + 3) - 1] = lines[(crosshairPulseIndex + 3) - 1].Replace("//", string.Empty);
+                    lines[(crosshairPulseIndex + 4) - 1] = lines[(crosshairPulseIndex + 4) - 1].Replace("//", string.Empty);
+                    lines[(crosshairPulseIndex + 5) - 1] = lines[(crosshairPulseIndex + 5) - 1].Replace("//", string.Empty);
                 }
                 else
                 {
                     lines[(crosshairPulseIndex + 0) - 1] = $"//{lines[(crosshairPulseIndex + 0) - 1]}";
                     lines[(crosshairPulseIndex + 1) - 1] = $"//{lines[(crosshairPulseIndex + 1) - 1]}";
+                    lines[(crosshairPulseIndex + 2) - 1] = $"//{lines[(crosshairPulseIndex + 2) - 1]}";
+                    lines[(crosshairPulseIndex + 3) - 1] = $"//{lines[(crosshairPulseIndex + 3) - 1]}";
+                    lines[(crosshairPulseIndex + 4) - 1] = $"//{lines[(crosshairPulseIndex + 4) - 1]}";
+                    lines[(crosshairPulseIndex + 5) - 1] = $"//{lines[(crosshairPulseIndex + 5) - 1]}";
                 }
 
                 File.WriteAllLines(animations, lines);

--- a/rayshud-Installer/Main.cs
+++ b/rayshud-Installer/Main.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using SharpRaven;
 using SharpRaven.Data;
 using System;
@@ -556,8 +556,9 @@ namespace rayshud_Installer
                 }
 
                 // Spy Disguise Image and Uber Animation - uncomment all
-                var disguiseImageIndex = 87;
-                var uberAnimationIndex = 104;
+                var crosshairPulseIndex = 77;
+                var disguiseImageIndex = 84;
+                var uberAnimationIndex = 99;
                 var lines = File.ReadAllLines(animations);
                 lines[(disguiseImageIndex + 0) - 1] = lines[(disguiseImageIndex + 0) - 1].Replace("//", string.Empty);
                 lines[(disguiseImageIndex + 1) - 1] = lines[(disguiseImageIndex + 1) - 1].Replace("//", string.Empty);
@@ -615,13 +616,13 @@ namespace rayshud_Installer
                 // 8. Crosshair Pulse - enable or disable by commenting out the lines
                 if (settings.XHairPulse)
                 {
-                    lines[80 - 1] = lines[80 - 1].Replace("//", string.Empty);
-                    lines[81 - 1] = lines[81 - 1].Replace("//", string.Empty);
+                    lines[(crosshairPulseIndex + 0) - 1] = lines[(crosshairPulseIndex + 0) - 1].Replace("//", string.Empty);
+                    lines[(crosshairPulseIndex + 1) - 1] = lines[(crosshairPulseIndex + 1) - 1].Replace("//", string.Empty);
                 }
                 else
                 {
-                    lines[80 - 1] = $"//{lines[80 - 1]}";
-                    lines[81 - 1] = $"//{lines[81 - 1]}";
+                    lines[(crosshairPulseIndex + 0) - 1] = $"//{lines[(crosshairPulseIndex + 0) - 1]}";
+                    lines[(crosshairPulseIndex + 1) - 1] = $"//{lines[(crosshairPulseIndex + 1) - 1]}";
                 }
 
                 File.WriteAllLines(animations, lines);

--- a/rayshud-Installer/Main.cs
+++ b/rayshud-Installer/Main.cs
@@ -76,7 +76,7 @@ namespace rayshud_Installer
                 textFromURL = client.DownloadString(Properties.Settings.Default.InstallerVersion);
                 textFromURLArray = textFromURL.Split('\n');
                 // Retrieve and compare the installer version numbers
-                if (textFromURLArray[textFromURLArray.Length - 2] != $"[assembly: AssemblyFileVersion(\"{versionInfo.FileVersion}\")]")
+                if (textFromURLArray[textFromURLArray.Length - 2] != $"[assembly: AssemblyVersion(\"{versionInfo.FileVersion}\")]")
                     MessageBox.Show(Properties.Settings.Default.InstallerVersion, "New Installer Version Available!", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (Exception ex)
@@ -236,6 +236,9 @@ namespace rayshud_Installer
                 // Main Menu Class Images - off (false) or on (true)
                 cbMenuClassImages.Checked = settings.MenuClassImages;
 
+                // Damage Value Above Health - health (false) or ammo (true)
+                cbDamageValuePos.Checked = settings.DamageValuePos;
+
                 // Ubercharge Animation - Flash (1), Solid (2) or Rainbow (3)
                 switch (settings.UberAnimation)
                 {
@@ -363,6 +366,7 @@ namespace rayshud_Installer
             WriteToSettings("AmmoReserve", settings.AmmoReserve);
             WriteToSettings("AmmoClipLow", settings.AmmoClipLow);
             WriteToSettings("AmmoReserveLow", settings.AmmoReserveLow);
+            WriteToSettings("DamageValuePos", settings.DamageValuePos.ToString());
             WriteToSettings("TF2Directory", settings.TF2Directory);
             WriteToSettings("LastModified", DateTime.Now.ToString(CultureInfo.CurrentCulture));
             txtLastModified.Text = DateTime.Now.ToString(CultureInfo.CurrentCulture);
@@ -475,6 +479,7 @@ namespace rayshud_Installer
                 var teammenu = $"{TF2Directory}\\rayshud\\customizations\\Team Menu";
                 var playerhealth = $"{TF2Directory}\\rayshud\\customizations\\Player Health";
                 var mainmenu = $"{TF2Directory}\\rayshud\\resource\\ui\\mainmenuoverride.res";
+                var damage = $"{TF2Directory}\\rayshud\\resource\\ui\\huddamageaccount.res";
 
                 // 1. Main Menu Style - either classic or modern, copy and replace existing files
                 if (settings.HUDVersion)
@@ -829,6 +834,14 @@ namespace rayshud_Installer
                 lines[46 - 1] = $"\t\t\"CrosshairDamage\"\t\t\t\t\"{settings.XHairPulseColor}\"";
                 File.WriteAllLines(colorScheme, lines);
 
+                // 13. Damage Value Position - either above health or ammo, change the xpos value in huddamageaccount.res
+                lines = File.ReadAllLines(damage);
+                if (settings.DamageValuePos)
+                    lines[22 - 1] = "\t\t\"xpos\"\t\t\t\"c+108\"";
+                else
+                    lines[22 - 1] = "\t\t\"xpos\"\t\t\t\"c-188\"";
+                File.WriteAllLines(damage, lines);
+
                 MessageBox.Show(Properties.Settings.Default.SuccessUpdate, "Changes Saved!", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (Exception ex)
@@ -1006,6 +1019,11 @@ namespace rayshud_Installer
         private void cbMenuClassImages_CheckedChanged(object sender, EventArgs e)
         {
             settings.MenuClassImages = cbMenuClassImages.Checked;
+        }
+
+        private void cbDamageValuePos_CheckedChanged(object sender, EventArgs e)
+        {
+            settings.DamageValuePos = cbDamageValuePos.Checked;
         }
 
         private void rbChatBox_CheckedChanged(object sender, EventArgs e)
@@ -1198,6 +1216,7 @@ namespace rayshud_Installer
             settings.DisguiseImage = false;
             settings.DefaultMenuBG = false;
             settings.MenuClassImages = false;
+            settings.DamageValuePos = false;
             settings.UberAnimation = 1;
             settings.UberBarColor = "235 226 202 255";
             settings.UberFullColor = "255 50 255 255";
@@ -1234,6 +1253,7 @@ namespace rayshud_Installer
         public bool DisguiseImage { get; set; }
         public bool DefaultMenuBG { get; set; }
         public bool MenuClassImages { get; set; }
+        public bool DamageValuePos { get; set; }
         public int UberAnimation { get; set; }
         public string UberBarColor { get; set; }
         public string UberFullColor { get; set; }

--- a/rayshud-Installer/Main.cs
+++ b/rayshud-Installer/Main.cs
@@ -77,7 +77,7 @@ namespace rayshud_Installer
                 textFromURLArray = textFromURL.Split('\n');
                 // Retrieve and compare the installer version numbers
                 if (textFromURLArray[textFromURLArray.Length - 2] != $"[assembly: AssemblyVersion(\"{versionInfo.FileVersion}\")]")
-                    MessageBox.Show(Properties.Settings.Default.InstallerVersion, "New Installer Version Available!", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    MessageBox.Show(Properties.Settings.Default.InstallerUpdate, "New Installer Version Available!", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (Exception ex)
             {

--- a/rayshud-Installer/Properties/AssemblyInfo.cs
+++ b/rayshud-Installer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/rayshud-Installer/Properties/Settings.Designer.cs
+++ b/rayshud-Installer/Properties/Settings.Designer.cs
@@ -50,7 +50,7 @@ namespace rayshud_Installer.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-i" +
+        [global::System.Configuration.DefaultSettingValueAttribute("https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-I" +
             "nstaller/settings.json")]
         public string GitSettings {
             get {
@@ -262,6 +262,32 @@ namespace rayshud_Installer.Properties {
             }
             set {
                 this["ErrorRemove"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-I" +
+            "nstaller/Properties/AssemblyInfo.cs")]
+        public string InstallerVersion {
+            get {
+                return ((string)(this["InstallerVersion"]));
+            }
+            set {
+                this["InstallerVersion"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("A new version of the installer is available on GitHub! Download it here: https://" +
+            "github.com/CriticalFlaw/rayshud-Installer/releases")]
+        public string InstallerUpdate {
+            get {
+                return ((string)(this["InstallerUpdate"]));
+            }
+            set {
+                this["InstallerUpdate"] = value;
             }
         }
     }

--- a/rayshud-Installer/Properties/Settings.settings
+++ b/rayshud-Installer/Properties/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)">master</Value>
     </Setting>
     <Setting Name="GitSettings" Type="System.String" Scope="User">
-      <Value Profile="(Default)">https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-installer/settings.json</Value>
+      <Value Profile="(Default)">https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-Installer/settings.json</Value>
     </Setting>
     <Setting Name="GitVersion" Type="System.String" Scope="User">
       <Value Profile="(Default)">https://raw.githubusercontent.com/raysfire/rayshud/master/README.md</Value>
@@ -61,6 +61,12 @@
     </Setting>
     <Setting Name="ErrorRemove" Type="System.String" Scope="User">
       <Value Profile="(Default)">An error occurred while attempting to remove rayshud</Value>
+    </Setting>
+    <Setting Name="InstallerVersion" Type="System.String" Scope="User">
+      <Value Profile="(Default)">https://raw.githubusercontent.com/CriticalFlaw/rayshud-Installer/master/rayshud-Installer/Properties/AssemblyInfo.cs</Value>
+    </Setting>
+    <Setting Name="InstallerUpdate" Type="System.String" Scope="User">
+      <Value Profile="(Default)">A new version of the installer is available on GitHub! Download it here: https://github.com/CriticalFlaw/rayshud-Installer/releases</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/rayshud-Installer/packages.config
+++ b/rayshud-Installer/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
-  <package id="SharpRaven" version="2.3.2" targetFramework="net45" />
+  <package id="SharpRaven" version="2.4.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/rayshud-Installer/rayshud-Installer.csproj
+++ b/rayshud-Installer/rayshud-Installer.csproj
@@ -41,13 +41,16 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="SharpRaven, Version=2.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpRaven.2.3.2\lib\net45\SharpRaven.dll</HintPath>
+    <Reference Include="SharpRaven, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpRaven.2.4.0\lib\net45\SharpRaven.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/rayshud-Installer/settings.json
+++ b/rayshud-Installer/settings.json
@@ -27,6 +27,7 @@
   "AmmoReserve": "72 255 255 255",
   "AmmoClipLow": "255 42 130 255",
   "AmmoReserveLow": "255 128 28 255",
+  "DamageValuePos": "False",
   "TF2Directory": "null",
   "LastModified": "4/22/2018 5:07:58 PM"
 }


### PR DESCRIPTION
- Added the option to select damage value position to be over health or ammo (#3)
- Added installer version checking, it'll notify the user when a new version of the installer is available (#5)
- Fixed damage pulse not working on every cross-hair type (#4)
- Fixed the GitSettings value pointing to the wrong README URL
- Updated hud animation index values to match the latest rayshud version
- Updated NuGet packages